### PR TITLE
PWA-194: Checkout button doesn't work after canceled login

### DIFF
--- a/pages/Cart/components/PaymentBar/components/Content/components/CheckoutButton/index.jsx
+++ b/pages/Cart/components/PaymentBar/components/Content/components/CheckoutButton/index.jsx
@@ -11,15 +11,15 @@ import connect from './connector';
  * @returns {JSX}
  */
 const CheckoutButton = ({ isActive }) => (
-  <RippleButton
-    disabled={!isActive}
-    flat={false}
-    type="secondary"
-  >
-    <Link href={CHECKOUT_PATH}>
-      <I18n.Text string="cart.checkout" />
-    </Link>
-  </RippleButton>
+  <Link href={CHECKOUT_PATH}>
+    <RippleButton
+      disabled={!isActive}
+      flat={false}
+      type="secondary"
+    >
+      <I18n.Text string="cart.checkout"/>
+    </RippleButton>
+  </Link>
 );
 
 CheckoutButton.propTypes = {

--- a/pages/Cart/subscriptions.js
+++ b/pages/Cart/subscriptions.js
@@ -1,0 +1,20 @@
+import { CART_PATH } from '@shopgate/pwa-common-commerce/cart/constants';
+import { routeDidEnter } from '@shopgate/pwa-common/streams/history';
+import toggleCartIcon from 'Components/Navigator/actions/toggleCartIcon';
+import disableNavigatorSearch from 'Components/Navigator/actions/disableNavigatorSearch';
+
+/**
+ * Cart subscriptions.
+ * @param {Function} subscribe The subscribe function.
+ */
+export default function cart(subscribe) {
+  const cartRouteDidEnter$ = routeDidEnter(CART_PATH);
+
+  /**
+   * Gets triggered on entering the cart route.
+   */
+  subscribe(cartRouteDidEnter$, ({ dispatch }) => {
+    dispatch(toggleCartIcon(false));
+    dispatch(disableNavigatorSearch());
+  });
+}

--- a/pages/subscribers.js
+++ b/pages/subscribers.js
@@ -32,6 +32,7 @@ import search from 'Pages/Search/subscriptions';
 import reviews from 'Pages/Reviews/subscriptions';
 import filterbar from 'Components/FilterBar/subscriptions';
 import writeReview from 'Pages/WriteReview/subscriptions';
+import cart from 'Pages/Cart/subscriptions';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 // Extensions
 import extensions from 'Extensions/subscribers';
@@ -75,6 +76,7 @@ const subscriptions = [
   search,
   reviews,
   writeReview,
+  cart,
   // Extensions
   ...extensions,
 ];


### PR DESCRIPTION
- make link wrap the ripplebutton
- add subscriber to handle correct navigator display