### PR TITLE
CCP-203: Enable the GMD theme on iOS devices

### DIFF
--- a/components/FilterBar/index.jsx
+++ b/components/FilterBar/index.jsx
@@ -187,9 +187,20 @@ class FilterBar extends Component {
     // Only update the state if the current scroll delta has changed.
     if (delta !== 0) {
       const { offset } = this.state;
-      const nextOffset = this.isVisible
-        ? clamp(offset - delta, -elementHeight, 0)
-        : -elementHeight;
+
+      let nextOffset;
+
+      /**
+       * When the page is scrolled down (due to iOS rubber band effect)
+       * then force the position to be at the top.
+       */
+      if (scrollTop < 1) {
+        nextOffset = 0;
+      } else if (this.isVisible) {
+        nextOffset = clamp(offset - delta, -elementHeight, 0);
+      } else {
+        nextOffset = -elementHeight;
+      }
 
       if (delta < 0) {
         // Shift the origin if the scroll direction is upwards.

--- a/components/FilterBar/style.js
+++ b/components/FilterBar/style.js
@@ -7,7 +7,6 @@ const wrapper = css({
   position: 'fixed',
   width: '100%',
   zIndex: 3,
-  top: variables.navigator.height,
   transition: 'transform 100ms linear',
   willChange: 'transform',
 }).toString();

--- a/components/NavDrawer/__snapshots__/spec.jsx.snap
+++ b/components/NavDrawer/__snapshots__/spec.jsx.snap
@@ -78,7 +78,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -113,14 +113,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -268,14 +267,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -409,14 +407,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -570,7 +567,6 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -580,14 +576,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -730,14 +725,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -871,14 +865,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1019,14 +1012,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1160,14 +1152,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1319,14 +1310,13 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1565,7 +1555,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -1600,14 +1590,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -1755,14 +1744,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1896,14 +1884,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2038,14 +2025,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={true}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2181,7 +2167,6 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -2191,14 +2176,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -2341,14 +2325,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2482,14 +2465,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2630,14 +2612,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2771,14 +2752,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2930,14 +2910,13 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3176,7 +3155,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -3211,14 +3190,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -3366,14 +3344,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3507,14 +3484,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3649,14 +3625,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3792,7 +3767,6 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -3802,14 +3776,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -3952,14 +3925,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4093,14 +4065,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4241,14 +4212,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4382,14 +4352,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4541,14 +4510,13 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4792,7 +4760,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -4830,7 +4798,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   }
                 >
                   <div
-                    className="css-vk8a95 css-fvkmon"
+                    className="css-vk8a95 css-vcdqir"
                     data-test-id="NavDrawerLoginButton"
                   >
                     <div
@@ -4906,14 +4874,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5047,14 +5014,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5189,14 +5155,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5332,7 +5297,6 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -5342,14 +5306,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -5492,14 +5455,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5633,14 +5595,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5781,14 +5742,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5922,14 +5882,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6081,14 +6040,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6230,14 +6188,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   count={null}
                   href=""
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6448,7 +6405,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -6483,14 +6440,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -6638,14 +6594,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6779,14 +6734,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6921,14 +6875,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7064,7 +7017,6 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -7074,14 +7026,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -7224,14 +7175,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7365,14 +7315,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7513,14 +7462,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7654,14 +7602,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7813,14 +7760,13 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8100,7 +8046,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -8135,14 +8081,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -8290,14 +8235,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8431,14 +8375,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8573,14 +8516,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8716,7 +8658,6 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -8726,14 +8667,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -8876,14 +8816,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9017,14 +8956,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9165,14 +9103,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9306,14 +9243,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9465,14 +9401,13 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9706,7 +9641,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -9750,7 +9684,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/category"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -9795,7 +9728,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/favourite_list"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -9841,7 +9773,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={0}
       href="/cart"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -9889,7 +9820,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/page/shipping"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -9933,7 +9863,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/page/payment"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -9980,7 +9909,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/page/terms"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -10024,7 +9952,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/page/privacy"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -10086,7 +10013,6 @@ exports[`<NavDrawer /> should render without optional props 1`] = `
       count={null}
       href="/page/imprint"
       icon={[Function]}
-      link=""
       onClick={[Function]}
       primary={false}
       withIndicator={false}
@@ -10270,7 +10196,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -10305,14 +10231,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -10460,14 +10385,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10601,14 +10525,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10743,14 +10666,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10886,7 +10808,6 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -10896,14 +10817,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -11046,14 +10966,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11187,14 +11106,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11335,14 +11253,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11476,14 +11393,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11635,14 +11551,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11922,7 +11837,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
             style={Object {}}
           >
             <div
-              className="css-1xj3g9q"
+              className="css-1yjznb9"
             >
               <Portal
                 name="user-menu.container.before"
@@ -11957,14 +11872,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                       count={null}
                       href="/login"
                       icon={[Function]}
-                      link=""
                       onClick={[Function]}
                       primary={true}
                       withIndicator={false}
                     >
                       <div
                         aria-hidden={true}
-                        className="css-13azwyo css-31obrv"
+                        className="css-1uvch4f css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -12112,14 +12026,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12253,14 +12166,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/category"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12395,14 +12307,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/favourite_list"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12538,7 +12449,6 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={0}
                   href="/cart"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
@@ -12548,14 +12458,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                     count={null}
                     href="/cart"
                     icon={[Function]}
-                    link=""
                     onClick={[Function]}
                     primary={false}
                     withIndicator={false}
                   >
                     <div
                       aria-hidden={true}
-                      className="css-13azwyo"
+                      className="css-1uvch4f"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -12698,14 +12607,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/shipping"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12839,14 +12747,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/payment"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12987,14 +12894,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/terms"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -13128,14 +13034,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/privacy"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -13287,14 +13192,13 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   count={null}
                   href="/page/imprint"
                   icon={[Function]}
-                  link=""
                   onClick={[Function]}
                   primary={false}
                   withIndicator={false}
                 >
                   <div
                     aria-hidden={true}
-                    className="css-13azwyo"
+                    className="css-1uvch4f"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >

--- a/components/NavDrawer/__snapshots__/spec.jsx.snap
+++ b/components/NavDrawer/__snapshots__/spec.jsx.snap
@@ -78,7 +78,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -119,7 +119,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -273,7 +273,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -413,7 +413,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -582,7 +582,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -731,7 +731,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -871,7 +871,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1018,7 +1018,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1158,7 +1158,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1316,7 +1316,7 @@ exports[`<NavDrawer /> should not render a favorites link at all when feature fl
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1555,7 +1555,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -1596,7 +1596,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -1750,7 +1750,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -1890,7 +1890,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2031,7 +2031,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2182,7 +2182,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -2331,7 +2331,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2471,7 +2471,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2618,7 +2618,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2758,7 +2758,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -2916,7 +2916,7 @@ exports[`<NavDrawer /> should render favorites list link with an indicator 1`] =
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3155,7 +3155,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -3196,7 +3196,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -3350,7 +3350,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3490,7 +3490,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3631,7 +3631,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -3782,7 +3782,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -3931,7 +3931,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4071,7 +4071,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4218,7 +4218,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4358,7 +4358,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4516,7 +4516,7 @@ exports[`<NavDrawer /> should render favorites list link without an indicator 1`
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -4760,7 +4760,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -4798,7 +4798,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   }
                 >
                   <div
-                    className="css-vk8a95 css-vcdqir"
+                    className="css-vk8a95 css-txr3np"
                     data-test-id="NavDrawerLoginButton"
                   >
                     <div
@@ -4880,7 +4880,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5020,7 +5020,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5161,7 +5161,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5312,7 +5312,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -5461,7 +5461,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5601,7 +5601,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5748,7 +5748,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -5888,7 +5888,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6046,7 +6046,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6194,7 +6194,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged i
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6405,7 +6405,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -6446,7 +6446,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -6600,7 +6600,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6740,7 +6740,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -6881,7 +6881,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7032,7 +7032,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -7181,7 +7181,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7321,7 +7321,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7468,7 +7468,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7608,7 +7608,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -7766,7 +7766,7 @@ exports[`<NavDrawer /> should render the header properly when a user is logged o
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8046,7 +8046,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -8087,7 +8087,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -8241,7 +8241,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8381,7 +8381,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8522,7 +8522,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8673,7 +8673,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -8822,7 +8822,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -8962,7 +8962,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9109,7 +9109,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9249,7 +9249,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -9407,7 +9407,7 @@ exports[`<NavDrawer /> should render the navigation drawer opened 1`] = `
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10196,7 +10196,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -10237,7 +10237,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -10391,7 +10391,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10531,7 +10531,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10672,7 +10672,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -10823,7 +10823,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -10972,7 +10972,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11112,7 +11112,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11259,7 +11259,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11399,7 +11399,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11557,7 +11557,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -11837,7 +11837,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
             style={Object {}}
           >
             <div
-              className="css-1yjznb9"
+              className="css-409aqe"
             >
               <Portal
                 name="user-menu.container.before"
@@ -11878,7 +11878,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                     >
                       <div
                         aria-hidden={true}
-                        className="css-1uvch4f css-31obrv"
+                        className="css-klayg css-31obrv"
                         data-test-id="NavDrawerLink"
                         onClick={[Function]}
                       >
@@ -12032,7 +12032,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12172,7 +12172,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12313,7 +12313,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12464,7 +12464,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                   >
                     <div
                       aria-hidden={true}
-                      className="css-1uvch4f"
+                      className="css-klayg"
                       data-test-id="NavDrawerLink"
                       onClick={[Function]}
                     >
@@ -12613,7 +12613,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12753,7 +12753,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -12900,7 +12900,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -13040,7 +13040,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >
@@ -13198,7 +13198,7 @@ exports[`<NavDrawer /> should trigger the toggle navigation callback when clicke
                 >
                   <div
                     aria-hidden={true}
-                    className="css-1uvch4f"
+                    className="css-klayg"
                     data-test-id="NavDrawerLink"
                     onClick={[Function]}
                   >

--- a/components/NavDrawer/components/Header/style.js
+++ b/components/NavDrawer/components/Header/style.js
@@ -14,10 +14,7 @@ const loggedIn = css({
   justifyContent: 'center',
   minHeight: variables.navigator.height,
   padding: `${variables.gap.small + 1}px ${variables.gap.big}px ${variables.gap.small - 1}px`,
-  paddingTop: [
-    `${variables.statusBar.height}px`,
-    'var(--safe-area-inset-top)',
-  ],
+  paddingTop: `calc(${variables.gap.small + 1}px + var(--safe-area-inset-top))`,
 }).toString();
 
 const ellipsis = {

--- a/components/NavDrawer/components/Header/style.js
+++ b/components/NavDrawer/components/Header/style.js
@@ -14,6 +14,10 @@ const loggedIn = css({
   justifyContent: 'center',
   minHeight: variables.navigator.height,
   padding: `${variables.gap.small + 1}px ${variables.gap.big}px ${variables.gap.small - 1}px`,
+  paddingTop: [
+    `${variables.statusBar.height}px`,
+    'var(--safe-area-inset-top)',
+  ],
 }).toString();
 
 const ellipsis = {

--- a/components/NavDrawer/components/Item/index.jsx
+++ b/components/NavDrawer/components/Item/index.jsx
@@ -17,7 +17,9 @@ const CLICK_DELAY = 250;
  * @param {string} props.link A url string (compatibility with `NAV_MENU_CONTENT_BEFORE` portal).
  * @param {Function} props.close A callback.
  */
-const handleClick = ({ onClick, href, link, close }) => {
+const handleClick = ({
+  onClick, href, link, close,
+}) => {
   setTimeout(() => {
     const url = href || link;
     // Perform onClick callback
@@ -90,7 +92,6 @@ Item.propTypes = {
     PropTypes.string,
   ]),
   href: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-  link: PropTypes.string, // eslint-disable-line react/no-unused-prop-types // Alias for href.
   icon: PropTypes.func,
   onClick: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
   primary: PropTypes.bool,
@@ -102,7 +103,6 @@ Item.defaultProps = {
   close: () => {},
   count: null,
   href: '',
-  link: '',
   icon: null,
   onClick: () => {},
   primary: false,

--- a/components/NavDrawer/components/Item/style.js
+++ b/components/NavDrawer/components/Item/style.js
@@ -4,6 +4,12 @@ import variables from 'Styles/variables';
 
 const container = css({
   position: 'relative',
+  ':first-child': {
+    paddingTop: [
+      `${variables.statusBar.height}px`,
+      'var(--safe-area-inset-top)',
+    ],
+  },
 }).toString();
 
 const grid = css({

--- a/components/NavDrawer/components/Item/style.js
+++ b/components/NavDrawer/components/Item/style.js
@@ -5,10 +5,7 @@ import variables from 'Styles/variables';
 const container = css({
   position: 'relative',
   ':first-child': {
-    paddingTop: [
-      `${variables.statusBar.height}px`,
-      'var(--safe-area-inset-top)',
-    ],
+    paddingTop: 'var(--safe-area-inset-top)',
   },
 }).toString();
 

--- a/components/NavDrawer/components/Layout/style.js
+++ b/components/NavDrawer/components/Layout/style.js
@@ -1,5 +1,6 @@
 import { css } from 'glamor';
 import colors from 'Styles/colors';
+import variables from 'Styles/variables';
 
 const duration = 300;
 const easing = 'cubic-bezier(0.25, 0.1, 0.25, 1)';
@@ -17,6 +18,10 @@ const content = css({
   color: colors.dark,
   background: colors.light,
   WebkitOverflowScrolling: 'touch',
+  paddingBottom: [
+    `${variables.tabBar.height}px`,
+    `calc(${variables.tabBar.height}px + var(--safe-area-inset-bottom))`,
+  ],
 }).toString();
 
 const drawerAnimation = {

--- a/components/NavDrawer/components/Layout/style.js
+++ b/components/NavDrawer/components/Layout/style.js
@@ -1,6 +1,5 @@
 import { css } from 'glamor';
 import colors from 'Styles/colors';
-import variables from 'Styles/variables';
 
 const duration = 300;
 const easing = 'cubic-bezier(0.25, 0.1, 0.25, 1)';
@@ -18,10 +17,7 @@ const content = css({
   color: colors.dark,
   background: colors.light,
   WebkitOverflowScrolling: 'touch',
-  paddingBottom: [
-    `${variables.tabBar.height}px`,
-    `calc(${variables.tabBar.height}px + var(--safe-area-inset-bottom))`,
-  ],
+  paddingBottom: 'var(--safe-area-inset-bottom)',
 }).toString();
 
 const drawerAnimation = {

--- a/components/Navigator/components/CartButton/__snapshots__/spec.jsx.snap
+++ b/components/Navigator/components/CartButton/__snapshots__/spec.jsx.snap
@@ -18,7 +18,6 @@ exports[`<CartButton /> should not be visible with prop visible set to false 1`]
   >
     <CartIcon />
     <CartButtonBadge
-      className="css-ggepo6"
       productCount={0}
     />
   </Ripple>
@@ -49,7 +48,6 @@ exports[`<CartButton /> should render with cartProductCount beeing set to 4 1`] 
   >
     <CartIcon />
     <CartButtonBadge
-      className="css-ggepo6"
       productCount={4}
     />
   </Ripple>
@@ -80,7 +78,6 @@ exports[`<CartButton /> should show '99+' if the cart amount is higher 1`] = `
   >
     <CartIcon />
     <CartButtonBadge
-      className="css-ggepo6"
       productCount={115}
     />
   </Ripple>
@@ -111,7 +108,6 @@ exports[`<CartButton /> should transition if it has cart amount 1`] = `
   >
     <CartIcon />
     <CartButtonBadge
-      className="css-ggepo6"
       productCount={5}
     />
   </Ripple>

--- a/components/Navigator/components/CartButton/components/CartButtonBadge/index.jsx
+++ b/components/Navigator/components/CartButton/components/CartButtonBadge/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CART_MAX_ITEMS } from 'Pages/Cart/constants';
+import styles from './style';
 
 /**
  * The cart button badge component.
@@ -16,17 +17,12 @@ const CartButtonBadge = (props) => {
   }
 
   return (
-    <div className={props.className}>{productCount}</div>
+    <div className={styles}>{productCount}</div>
   );
 };
 
 CartButtonBadge.propTypes = {
   productCount: PropTypes.number.isRequired,
-  className: PropTypes.string,
-};
-
-CartButtonBadge.defaultProps = {
-  className: '',
 };
 
 export default CartButtonBadge;

--- a/components/Navigator/components/CartButton/components/CartButtonBadge/style.js
+++ b/components/Navigator/components/CartButton/components/CartButtonBadge/style.js
@@ -1,0 +1,21 @@
+import { css } from 'glamor';
+import colors from 'Styles/colors';
+import variables from 'Styles/variables';
+
+export default css({
+  position: 'absolute',
+  fontSize: '0.75rem',
+  lineHeight: 1.4,
+  fontWeight: 700,
+  background: colors.primaryContrast,
+  color: colors.primary,
+  borderRadius: variables.gap.small,
+  height: variables.gap.big,
+  minWidth: variables.gap.big,
+  paddingLeft: (variables.gap.small / 2),
+  paddingRight: (variables.gap.small / 2),
+  top: '50%',
+  left: '50%',
+  transform: 'translate3d(15%, -110%, 0)',
+  boxShadow: '0 1px 1px rgba(0, 0, 0, 0.25)',
+});

--- a/components/Navigator/components/CartButton/index.jsx
+++ b/components/Navigator/components/CartButton/index.jsx
@@ -81,7 +81,7 @@ class CartButton extends Component {
       >
         <Ripple fill className={styles.buttonContent} size={navigator.height}>
           <CartIcon />
-          <CartButtonBadge className={styles.badge} productCount={this.props.cartProductCount} />
+          <CartButtonBadge productCount={this.props.cartProductCount} />
         </Ripple>
       </button>
     );

--- a/components/Navigator/components/CartButton/style.js
+++ b/components/Navigator/components/CartButton/style.js
@@ -27,24 +27,7 @@ const buttonContent = css({
   color: colors.primaryContrast,
 }).toString();
 
-const badge = css({
-  position: 'absolute',
-  fontSize: '0.75rem',
-  lineHeight: 1.4,
-  fontWeight: 700,
-  background: colors.primaryContrast,
-  color: colors.primary,
-  borderRadius: variables.gap.small,
-  height: variables.gap.big,
-  minWidth: variables.gap.big,
-  paddingLeft: (variables.gap.small / 2),
-  paddingRight: (variables.gap.small / 2),
-  transform: 'translate3d(7px, -10px, 0)',
-  boxShadow: '0 1px 1px rgba(0, 0, 0, 0.25)',
-}).toString();
-
 export default {
   button,
   buttonContent,
-  badge,
 };

--- a/components/Navigator/components/Content/components/Search/components/SearchSuggestions/style.js
+++ b/components/Navigator/components/Content/components/Search/components/SearchSuggestions/style.js
@@ -4,7 +4,7 @@ import variables from 'Styles/variables';
 
 const container = css({
   position: 'fixed',
-  top: variables.navigator.height,
+  top: `calc(${variables.navigator.height}px + var(--safe-area-inset-top))`,
   borderTop: `${variables.gap.small / 2}px solid ${colors.shade8}`,
   left: 0,
   right: 0,

--- a/components/Navigator/components/Content/components/Search/style.js
+++ b/components/Navigator/components/Content/components/Search/style.js
@@ -17,9 +17,11 @@ const input = css({
   border: `1px ${colors.shade7} solid`,
   padding: `0 ${variables.gap.big}px`,
   background: colors.light,
-  lineHeight: '46px',
+  lineHeight: '19px',
+  height: '46px',
   borderRadius: '2px',
   outline: 'none',
+  WebkitAppearance: 'none',
 }).toString();
 
 const overlay = css({

--- a/components/Navigator/style.js
+++ b/components/Navigator/style.js
@@ -4,14 +4,8 @@ import variables from 'Styles/variables';
 
 const header = css({
   position: 'fixed',
-  height: [
-    `${variables.navigator.height + variables.statusBar.height}px`,
-    `calc(${variables.navigator.height}px + var(--safe-area-inset-top))`,
-  ],
-  paddingTop: [
-    `${variables.statusBar.height}px`,
-    'var(--safe-area-inset-top)',
-  ],
+  height: `calc(${variables.navigator.height}px + var(--safe-area-inset-top))`,
+  paddingTop: 'var(--safe-area-inset-top)',
   left: 0,
   top: 0,
   width: '100%',

--- a/components/Navigator/style.js
+++ b/components/Navigator/style.js
@@ -4,7 +4,14 @@ import variables from 'Styles/variables';
 
 const header = css({
   position: 'fixed',
-  height: variables.navigator.height,
+  height: [
+    `${variables.navigator.height + variables.statusBar.height}px`,
+    `calc(${variables.navigator.height}px + var(--safe-area-inset-top))`,
+  ],
+  paddingTop: [
+    `${variables.statusBar.height}px`,
+    'var(--safe-area-inset-top)',
+  ],
   left: 0,
   top: 0,
   width: '100%',

--- a/components/Sheet/__snapshots__/spec.jsx.snap
+++ b/components/Sheet/__snapshots__/spec.jsx.snap
@@ -114,7 +114,7 @@ exports[`<Sheet /> should open 1`] = `
           </Grid>
         </Header>
         <div
-          className="css-1tkozuj false"
+          className="css-1aon90l false"
         >
           <div
             key=".0"
@@ -224,7 +224,7 @@ exports[`<Sheet /> should render closed without content 1`] = `
     onOpen={[Function]}
   >
     <div
-      className="css-1tkozuj false"
+      className="css-1aon90l false"
     />
   </Drawer>
   <Backdrop
@@ -256,7 +256,7 @@ exports[`<Sheet /> should render opened without content 1`] = `
     onOpen={[Function]}
   >
     <div
-      className="css-1tkozuj false"
+      className="css-1aon90l false"
     />
   </Drawer>
   <Backdrop
@@ -292,7 +292,7 @@ exports[`<Sheet /> should render with content and title 1`] = `
       title="Test-Title"
     />
     <div
-      className="css-1tkozuj false"
+      className="css-1aon90l false"
     >
       <div
         key=".0"
@@ -438,7 +438,7 @@ exports[`<Sheet /> should trigger onClose callback and close the Sheet 1`] = `
           </Grid>
         </Header>
         <div
-          className="css-1tkozuj false"
+          className="css-1aon90l false"
         >
           <div
             key=".0"

--- a/components/Sheet/style.js
+++ b/components/Sheet/style.js
@@ -17,7 +17,13 @@ const shadow = css({
 }).toString();
 
 const content = css({
-  maxHeight: `calc(100vh - ${variables.navigator.height}px)`, // 56px (Sheet Header)
+  maxHeight: [
+    `calc(100vh - ${variables.navigator.height}px)`,
+    `calc(100vh - ${variables.navigator.height}px - var(--safe-area-inset-top))`,
+  ],
+  paddingBottom: [
+    'var(--safe-area-inset-bottom)',
+  ],
   overflowY: 'scroll',
   WebkitOverflowScrolling: 'touch',
 }).toString();

--- a/components/SnackBar/__snapshots__/spec.jsx.snap
+++ b/components/SnackBar/__snapshots__/spec.jsx.snap
@@ -16,13 +16,13 @@ exports[`<SnackBar /> should render component without action 1`] = `
   <SnackBar>
     <Connect(Toast)
       actionButton={[Function]}
-      className="css-1ogjxzw"
+      className="css-u8tmgv"
       container={[Function]}
       message={[Function]}
     >
       <Toast
         actionButton={[Function]}
-        className="css-1ogjxzw"
+        className="css-u8tmgv"
         container={[Function]}
         dispatchAction={[Function]}
         hasNextToast={false}
@@ -50,14 +50,14 @@ exports[`<SnackBar /> should render component without action 1`] = `
                 "out": "",
               }
             }
-            className="css-1ogjxzw"
+            className="css-u8tmgv"
             isOpen={true}
             onClose={[Function]}
             onDidClose={[Function]}
             onOpen={[Function]}
           >
             <div
-              className="css-1ogjxzw css-1rg7udn css-1dwe0qx"
+              className="css-u8tmgv css-1rg7udn css-1dwe0qx"
               onAnimationEnd={[Function]}
               style={Object {}}
             >
@@ -111,13 +111,13 @@ exports[`<SnackBar /> shuld render component with action button 1`] = `
   <SnackBar>
     <Connect(Toast)
       actionButton={[Function]}
-      className="css-1ogjxzw"
+      className="css-u8tmgv"
       container={[Function]}
       message={[Function]}
     >
       <Toast
         actionButton={[Function]}
-        className="css-1ogjxzw"
+        className="css-u8tmgv"
         container={[Function]}
         dispatchAction={[Function]}
         hasNextToast={false}
@@ -146,14 +146,14 @@ exports[`<SnackBar /> shuld render component with action button 1`] = `
                 "out": "",
               }
             }
-            className="css-1ogjxzw"
+            className="css-u8tmgv"
             isOpen={true}
             onClose={[Function]}
             onDidClose={[Function]}
             onOpen={[Function]}
           >
             <div
-              className="css-1ogjxzw css-1rg7udn css-1dwe0qx"
+              className="css-u8tmgv css-1rg7udn css-1dwe0qx"
               onAnimationEnd={[Function]}
               style={Object {}}
             >

--- a/components/SnackBar/__snapshots__/spec.jsx.snap
+++ b/components/SnackBar/__snapshots__/spec.jsx.snap
@@ -16,13 +16,13 @@ exports[`<SnackBar /> should render component without action 1`] = `
   <SnackBar>
     <Connect(Toast)
       actionButton={[Function]}
-      className="css-1nw5ecr"
+      className="css-1ogjxzw"
       container={[Function]}
       message={[Function]}
     >
       <Toast
         actionButton={[Function]}
-        className="css-1nw5ecr"
+        className="css-1ogjxzw"
         container={[Function]}
         dispatchAction={[Function]}
         hasNextToast={false}
@@ -50,14 +50,14 @@ exports[`<SnackBar /> should render component without action 1`] = `
                 "out": "",
               }
             }
-            className="css-1nw5ecr"
+            className="css-1ogjxzw"
             isOpen={true}
             onClose={[Function]}
             onDidClose={[Function]}
             onOpen={[Function]}
           >
             <div
-              className="css-1nw5ecr css-1rg7udn css-1dwe0qx"
+              className="css-1ogjxzw css-1rg7udn css-1dwe0qx"
               onAnimationEnd={[Function]}
               style={Object {}}
             >
@@ -111,13 +111,13 @@ exports[`<SnackBar /> shuld render component with action button 1`] = `
   <SnackBar>
     <Connect(Toast)
       actionButton={[Function]}
-      className="css-1nw5ecr"
+      className="css-1ogjxzw"
       container={[Function]}
       message={[Function]}
     >
       <Toast
         actionButton={[Function]}
-        className="css-1nw5ecr"
+        className="css-1ogjxzw"
         container={[Function]}
         dispatchAction={[Function]}
         hasNextToast={false}
@@ -146,14 +146,14 @@ exports[`<SnackBar /> shuld render component with action button 1`] = `
                 "out": "",
               }
             }
-            className="css-1nw5ecr"
+            className="css-1ogjxzw"
             isOpen={true}
             onClose={[Function]}
             onDidClose={[Function]}
             onOpen={[Function]}
           >
             <div
-              className="css-1nw5ecr css-1rg7udn css-1dwe0qx"
+              className="css-1ogjxzw css-1rg7udn css-1dwe0qx"
               onAnimationEnd={[Function]}
               style={Object {}}
             >

--- a/components/SnackBar/__snapshots__/spec.jsx.snap
+++ b/components/SnackBar/__snapshots__/spec.jsx.snap
@@ -16,13 +16,13 @@ exports[`<SnackBar /> should render component without action 1`] = `
   <SnackBar>
     <Connect(Toast)
       actionButton={[Function]}
-      className="css-u8tmgv"
+      className="css-13mxj7e"
       container={[Function]}
       message={[Function]}
     >
       <Toast
         actionButton={[Function]}
-        className="css-u8tmgv"
+        className="css-13mxj7e"
         container={[Function]}
         dispatchAction={[Function]}
         hasNextToast={false}
@@ -50,14 +50,14 @@ exports[`<SnackBar /> should render component without action 1`] = `
                 "out": "",
               }
             }
-            className="css-u8tmgv"
+            className="css-13mxj7e"
             isOpen={true}
             onClose={[Function]}
             onDidClose={[Function]}
             onOpen={[Function]}
           >
             <div
-              className="css-u8tmgv css-1rg7udn css-1dwe0qx"
+              className="css-13mxj7e css-1rg7udn css-1dwe0qx"
               onAnimationEnd={[Function]}
               style={Object {}}
             >
@@ -111,13 +111,13 @@ exports[`<SnackBar /> shuld render component with action button 1`] = `
   <SnackBar>
     <Connect(Toast)
       actionButton={[Function]}
-      className="css-u8tmgv"
+      className="css-13mxj7e"
       container={[Function]}
       message={[Function]}
     >
       <Toast
         actionButton={[Function]}
-        className="css-u8tmgv"
+        className="css-13mxj7e"
         container={[Function]}
         dispatchAction={[Function]}
         hasNextToast={false}
@@ -146,14 +146,14 @@ exports[`<SnackBar /> shuld render component with action button 1`] = `
                 "out": "",
               }
             }
-            className="css-u8tmgv"
+            className="css-13mxj7e"
             isOpen={true}
             onClose={[Function]}
             onDidClose={[Function]}
             onOpen={[Function]}
           >
             <div
-              className="css-u8tmgv css-1rg7udn css-1dwe0qx"
+              className="css-13mxj7e css-1rg7udn css-1dwe0qx"
               onAnimationEnd={[Function]}
               style={Object {}}
             >

--- a/components/SnackBar/style.js
+++ b/components/SnackBar/style.js
@@ -1,14 +1,10 @@
 import { css } from 'glamor';
-import variables from 'Styles/variables';
 
 const drawer = css({
   width: '100%',
   background: 'black',
   padding: '7px 24px',
-  bottom: [
-    `${variables.tabBar.height}px`,
-    `calc(${variables.tabBar.height}px + var(--safe-area-inset-bottom))`,
-  ],
+  bottom: 'calc(var(--tabbar-height) + var(--safe-area-inset-bottom))',
 }).toString();
 
 export default {

--- a/components/SnackBar/style.js
+++ b/components/SnackBar/style.js
@@ -1,9 +1,14 @@
 import { css } from 'glamor';
+import variables from 'Styles/variables';
 
 const drawer = css({
   width: '100%',
   background: 'black',
   padding: '7px 24px',
+  bottom: [
+    `${variables.tabBar.height}px`,
+    `calc(${variables.tabBar.height}px + var(--safe-area-inset-bottom))`,
+  ],
 }).toString();
 
 export default {

--- a/components/SnackBar/style.js
+++ b/components/SnackBar/style.js
@@ -5,6 +5,7 @@ const drawer = css({
   background: 'black',
   padding: '7px 24px',
   bottom: 'calc(var(--tabbar-height) + var(--safe-area-inset-bottom))',
+  zIndex: 2,
 }).toString();
 
 export default {

--- a/components/View/index.jsx
+++ b/components/View/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import Swipeable from 'react-swipeable';
 import throttle from 'lodash/throttle';
+import event from '@shopgate/pwa-core/classes/Event';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 import connect from './connector';
 import styles from './style';
@@ -61,6 +62,12 @@ class View extends Component {
     // Store the active pathname at instantiation
     this.pathname = context.routePath;
     this.element = null;
+
+    this.state = {
+      keyboardHeight: 0,
+    };
+
+    event.addCallback('keyboardWillChange', this.handleKeyboardChange);
   }
 
   /**
@@ -105,6 +112,18 @@ class View extends Component {
    */
   setRef = (ref) => {
     this.element = ref;
+  }
+
+  /**
+   * Handles a keyboard change event.
+   * @param {boolean} open If the keyboard is now open.
+   * @param {boolean} overlap The height of the keyboard.
+   */
+  handleKeyboardChange = ({ open, overlap }) => {
+    const height = open ? overlap : 0;
+    this.setState({
+      keyboardHeight: height,
+    });
   }
 
   /**
@@ -171,8 +190,8 @@ class View extends Component {
   render() {
     let contentStyle = styles.content(
       this.props.hasNavigator,
-      false,
-      this.props.isFullscreen
+      this.props.isFullscreen,
+      this.state.keyboardHeight
     );
 
     const { children } = this.props;

--- a/components/View/index.jsx
+++ b/components/View/index.jsx
@@ -26,6 +26,7 @@ class View extends Component {
       script: PropTypes.array,
       style: PropTypes.array,
     }),
+    isFullscreen: PropTypes.bool,
     style: PropTypes.shape(),
     title: PropTypes.string,
     viewTop: PropTypes.bool,
@@ -39,6 +40,7 @@ class View extends Component {
       script: [],
       style: [],
     },
+    isFullscreen: false,
     style: null,
     title: '',
     viewTop: true,
@@ -167,7 +169,11 @@ class View extends Component {
    * @returns {JSX}
    */
   render() {
-    let contentStyle = styles.content(this.props.hasNavigator);
+    let contentStyle = styles.content(
+      this.props.hasNavigator,
+      false,
+      this.props.isFullscreen
+    );
 
     const { children } = this.props;
 

--- a/components/View/style.js
+++ b/components/View/style.js
@@ -15,7 +15,6 @@ const container = css({
 /**
  * Creates the content style.
  * @param {boolean} hasNavigator Whether to add the top offset when the navigator is visible.
- * @param {boolean} hasTabBar Whether to add the bottom offset when the tab bar is visible.
  * @param {boolean} isFullscreen Whether remove all offsets,
  *                  so that it's really fullscreen (including the notch).
  * @param {number} keyboardHeight The space that is taken by the keyboard.
@@ -23,20 +22,11 @@ const container = css({
  */
 const content = (
   hasNavigator = true,
-  hasTabBar = true,
   isFullscreen = false,
   keyboardHeight = 0
 ) => {
   const navHeight = hasNavigator ? variables.navigator.height : 0;
-  const navAndStatusBarHeight = [
-    `${navHeight + variables.statusBar.height}px`,
-    `calc(${navHeight}px + var(--safe-area-inset-top))`,
-  ];
-
-  const paddingBottom = hasTabBar ? [
-    `${variables.tabBar.height + keyboardHeight}px`,
-    `calc(${variables.tabBar.height + keyboardHeight}px + var(--safe-area-inset-bottom))`,
-  ] : keyboardHeight;
+  const navAndStatusBarHeight = `calc(${navHeight}px + var(--safe-area-inset-top))`;
 
   return css({
     background: colors.light,
@@ -46,7 +36,7 @@ const content = (
     width: '100%',
     position: 'absolute',
     top: isFullscreen ? 0 : navAndStatusBarHeight,
-    paddingBottom,
+    paddingBottom: `calc(var(--tabbar-height) + ${keyboardHeight}px + var(--safe-area-inset-bottom))`,
     bottom: 0,
     display: 'flex',
     flexDirection: 'column',

--- a/components/View/style.js
+++ b/components/View/style.js
@@ -15,30 +15,53 @@ const container = css({
 /**
  * Creates the content style.
  * @param {boolean} hasNavigator Whether to add the top offset when the navigator is visible.
+ * @param {boolean} hasTabBar Whether to add the bottom offset when the tab bar is visible.
+ * @param {boolean} isFullscreen Whether remove all offsets,
+ *                  so that it's really fullscreen (including the notch).
+ * @param {number} keyboardHeight The space that is taken by the keyboard.
  * @return {string} The content style class.
  */
-const content = (hasNavigator = true) => css({
-  background: colors.light,
-  overflow: 'auto',
-  overflowScrolling: 'touch',
-  WebkitOverflowScrolling: 'touch',
-  width: '100%',
-  position: 'absolute',
-  top: hasNavigator ? variables.navigator.height : 0,
-  bottom: 0,
-  display: 'flex',
-  flexDirection: 'column',
-  ':before': {
-    position: 'fixed',
-    display: 'block',
-    top: 0,
+const content = (
+  hasNavigator = true,
+  hasTabBar = true,
+  isFullscreen = false,
+  keyboardHeight = 0
+) => {
+  const navHeight = hasNavigator ? variables.navigator.height : 0;
+  const navAndStatusBarHeight = [
+    `${navHeight + variables.statusBar.height}px`,
+    `calc(${navHeight}px + var(--safe-area-inset-top))`,
+  ];
+
+  const paddingBottom = hasTabBar ? [
+    `${variables.tabBar.height + keyboardHeight}px`,
+    `calc(${variables.tabBar.height + keyboardHeight}px + var(--safe-area-inset-bottom))`,
+  ] : keyboardHeight;
+
+  return css({
+    background: colors.light,
+    overflow: 'auto',
+    overflowScrolling: 'touch',
+    WebkitOverflowScrolling: 'touch',
     width: '100%',
-    height: hasNavigator ? variables.navigator.height : 0,
-    zIndex: 3,
-    content: '""',
-    transition: 'box-shadow 100ms cubic-bezier(0.25, 0.1, 0.25, 1)',
-  },
-}).toString();
+    position: 'absolute',
+    top: isFullscreen ? 0 : navAndStatusBarHeight,
+    paddingBottom,
+    bottom: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    ':before': {
+      position: 'fixed',
+      display: 'block',
+      top: 0,
+      width: '100%',
+      height: isFullscreen ? 0 : navAndStatusBarHeight,
+      zIndex: 3,
+      content: '""',
+      transition: 'box-shadow 100ms cubic-bezier(0.25, 0.1, 0.25, 1)',
+    },
+  }).toString();
+};
 
 const contentShaded = css({
   ':before': {

--- a/components/Viewport/style.js
+++ b/components/Viewport/style.js
@@ -4,6 +4,22 @@ css.global('body', {
   userSelect: 'none',
 });
 
+/**
+ * Updates the page inset css variables
+ * @param {Object} pageInsets A page insets object
+ */
+export const updatePageInsets = (pageInsets) => {
+  const {
+    safeAreaInsetTop,
+    safeAreaInsetBottom,
+  } = pageInsets;
+
+  css.global(':root', {
+    '--safe-area-inset-top': `${safeAreaInsetTop}px`,
+    '--safe-area-inset-bottom': `${safeAreaInsetBottom}px`,
+  });
+};
+
 export default css({
   minHeight: '100vh',
   overflowX: 'hidden',

--- a/components/Viewport/style.js
+++ b/components/Viewport/style.js
@@ -1,5 +1,14 @@
 import { css } from 'glamor';
 
+/**
+ * By default the GMD theme doesn't have a tabbar. But it's conceivable that 3rd party developers
+ * might want to implement one via an extension. So the code which calculates content bottom
+ * paddings for example is prepared to deal with it. For now the value is initialized with 0.
+ */
+css.global('html', {
+  '--tabbar-height': '0px',
+});
+
 css.global('body', {
   userSelect: 'none',
 });

--- a/components/Viewport/subscriptions.js
+++ b/components/Viewport/subscriptions.js
@@ -1,0 +1,18 @@
+import { appDidStart$ } from '@shopgate/pwa-common/streams/app';
+import { getPageInsets } from '@shopgate/pwa-common/selectors/client';
+import { clientInformationDidUpdate$ } from '@shopgate/pwa-common/streams/client';
+import { updatePageInsets } from './style';
+/**
+ * App subscriptions.
+ * @param {Function} subscribe The subscribe function.
+ */
+export default function app(subscribe) {
+  const pageInsetsNeedUpdate$ = appDidStart$.merge(clientInformationDidUpdate$);
+
+  /**
+   * Gets triggered when the page insets changed.
+   */
+  subscribe(pageInsetsNeedUpdate$, ({ getState }) => {
+    updatePageInsets(getPageInsets(getState()));
+  });
+}

--- a/pages/Cart/components/CouponField/components/Layout/style.js
+++ b/pages/Cart/components/CouponField/components/Layout/style.js
@@ -27,6 +27,8 @@ const input = css({
   top: 0,
   outline: 0,
   bottom: 6,
+  padding: 0,
+  left: 0,
 }).toString();
 
 const easing = '450ms cubic-bezier(0.23, 1, 0.32, 1)';

--- a/pages/Cart/components/CouponField/connector.js
+++ b/pages/Cart/components/CouponField/connector.js
@@ -1,4 +1,5 @@
 import connect from '@shopgate/pwa-common/components/Router/helpers/connect';
+import { isIos } from '@shopgate/pwa-common/selectors/client';
 import addCouponsToCart from '@shopgate/pwa-common-commerce/cart/actions/addCouponsToCart';
 import { hasCouponSupport } from '@shopgate/pwa-common-commerce/cart/selectors';
 import { isCurrentViewLoading } from '@shopgate/pwa-common/selectors/view';
@@ -9,6 +10,7 @@ import { isCurrentViewLoading } from '@shopgate/pwa-common/selectors/view';
  * @return {Object} The extended component props.
  */
 const mapStateToProps = state => ({
+  isIos: isIos(state),
   isLoading: isCurrentViewLoading(state),
   isVisible: hasCouponSupport(state),
 });

--- a/pages/Cart/components/CouponField/index.jsx
+++ b/pages/Cart/components/CouponField/index.jsx
@@ -11,6 +11,7 @@ import { CART_INPUT_AUTO_SCROLL_DELAY } from '../../constants';
 class CouponField extends Component {
   static propTypes = {
     addCoupon: PropTypes.func,
+    isIos: PropTypes.bool,
     isLoading: PropTypes.bool,
     isVisible: PropTypes.bool,
     onToggleFocus: PropTypes.func,
@@ -18,6 +19,7 @@ class CouponField extends Component {
 
   static defaultProps = {
     addCoupon: () => {},
+    isIos: false,
     isLoading: false,
     isVisible: true,
     onToggleFocus: () => {},
@@ -87,11 +89,13 @@ class CouponField extends Component {
    * @param {boolean} isFocused Whether the input component is focused.
    */
   handleFocusChange = (isFocused) => {
-    if (isFocused) {
+    if (!this.props.isIos && isFocused) {
       /**
        * When the user focuses the coupon input, the keyboard will pop up an overlap the input.
        * Therefore the input has to be scrolled into the viewport again. Since between the focus and
        * the keyboard apearance some time ticks away, the execution of the scroll code is delayed.
+       *
+       * This should not happen on iOS devices, since their webviews behave different.
        */
       setTimeout(() => {
         const yOffset = -(window.innerHeight / 2) + getAbsoluteHeight(this.element);

--- a/pages/Cart/components/Item/components/Product/connector.js
+++ b/pages/Cart/components/Item/components/Product/connector.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { isIos } from '@shopgate/pwa-common/selectors/client';
 import deleteProductsFromCart from '@shopgate/pwa-common-commerce/cart/actions/deleteProductsFromCart';
 import updateProductsInCart from '@shopgate/pwa-common-commerce/cart/actions/updateProductsInCart';
 import { getCurrency } from '@shopgate/pwa-common-commerce/cart/selectors';
@@ -9,6 +10,7 @@ import { getCurrency } from '@shopgate/pwa-common-commerce/cart/selectors';
  * @return {Object} The extended component props.
  */
 const mapStateToProps = state => ({
+  isIos: isIos(state),
   currency: getCurrency(state),
 });
 

--- a/pages/Cart/components/Item/components/Product/index.jsx
+++ b/pages/Cart/components/Item/components/Product/index.jsx
@@ -34,11 +34,13 @@ class Product extends Component {
     product: PropTypes.shape().isRequired,
     quantity: PropTypes.number.isRequired,
     deleteProduct: PropTypes.func,
+    isIos: PropTypes.bool,
     onToggleFocus: PropTypes.func,
     updateProduct: PropTypes.func,
   };
 
   static defaultProps = {
+    isIos: false,
     deleteProduct: () => {},
     updateProduct: () => {},
     onToggleFocus: () => {},
@@ -87,11 +89,13 @@ class Product extends Component {
    * @param {boolean} [isEnabled=true] Tells if the edit mode is enabled, or disabled.
    */
   toggleEditMode = (isEnabled = true) => {
-    if (isEnabled) {
+    if (!this.props.isIos && isEnabled) {
       /**
        * When the user focuses the quantity input, the keyboard will pop up an overlap the input.
        * Therefore the input has to be scrolled into the viewport again. Since between the focus and
        * the keyboard apearance some time ticks away, the execution of the scroll code is delayed.
+       *
+       * This should not happen on iOS devices, since their webviews behave different.
        */
       setTimeout(() => {
         const yOffset = -(window.innerHeight / 2)

--- a/pages/Cart/style.js
+++ b/pages/Cart/style.js
@@ -32,7 +32,7 @@ const transitionStyles = {
  */
 const getContainerPaddingStyle = (bottom = variables.paymentBar.height) => ({
   paddingTop: variables.gap.small * 0.5,
-  paddingBottom: `calc(${bottom}px + var(--safe-area-inset-bottom))`,
+  paddingBottom: `${bottom}px`,
 });
 
 /**

--- a/pages/Cart/style.js
+++ b/pages/Cart/style.js
@@ -32,7 +32,7 @@ const transitionStyles = {
  */
 const getContainerPaddingStyle = (bottom = variables.paymentBar.height) => ({
   paddingTop: variables.gap.small * 0.5,
-  paddingBottom: bottom,
+  paddingBottom: `calc(${bottom}px + var(--safe-area-inset-bottom))`,
 });
 
 /**

--- a/pages/Filter/style.js
+++ b/pages/Filter/style.js
@@ -5,6 +5,9 @@ const container = css({
   background: colors.background,
   flexGrow: 1,
   paddingTop: 4,
+  paddingBottom: [
+    'var(--safe-area-inset-bottom)',
+  ],
 }).toString();
 
 const filterContainer = css({

--- a/pages/FilterAttribute/style.js
+++ b/pages/FilterAttribute/style.js
@@ -5,5 +5,8 @@ export default css({
   background: colors.background,
   flexGrow: 1,
   paddingTop: 4,
-  paddingBottom: 4,
+  paddingBottom: [
+    '4px',
+    'calc(4px + var(--safe-area-inset-bottom))',
+  ],
 }).toString();

--- a/pages/ProductGallery/index.jsx
+++ b/pages/ProductGallery/index.jsx
@@ -63,7 +63,7 @@ class ProductGallery extends Component {
     ];
 
     return (
-      <View title={title} hasNavigator={false}>
+      <View title={title} hasNavigator={false} isFullscreen>
         <div className={styles.navButton}>
           <BackButton />
         </div>

--- a/pages/ProductGallery/style.js
+++ b/pages/ProductGallery/style.js
@@ -20,10 +20,7 @@ const container = css({
 
 const navButton = css({
   position: 'fixed',
-  top: [
-    `${variables.statusBar.height}px`,
-    'var(--safe-area-inset-top)',
-  ],
+  top: 'var(--safe-area-inset-top)',
   left: 0,
   width: variables.navigator.height,
   color: colors.light,

--- a/pages/ProductGallery/style.js
+++ b/pages/ProductGallery/style.js
@@ -11,7 +11,7 @@ const fullSize = {
 const container = css({
   ...fullSize,
   background: colors.dark,
-  position: 'absolute',
+  position: 'fixed',
   top: 0,
   bottom: 0,
   left: 0,
@@ -20,7 +20,10 @@ const container = css({
 
 const navButton = css({
   position: 'fixed',
-  top: 0,
+  top: [
+    `${variables.statusBar.height}px`,
+    'var(--safe-area-inset-top)',
+  ],
   left: 0,
   width: variables.navigator.height,
   color: colors.light,
@@ -40,6 +43,16 @@ const slide = css({
 const sliderStyles = {
   container: css({
     height: '100%',
+  }).toString(),
+  indicator: css({
+    position: 'absolute',
+    bottom: [
+      '2px',
+      'calc(2px + var(--safe-area-inset-bottom))',
+    ],
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: 10,
   }).toString(),
 };
 

--- a/pages/subscribers.js
+++ b/pages/subscribers.js
@@ -22,6 +22,7 @@ import trackingSearch from '@shopgate/pwa-tracking/subscriptions/search';
 import trackingDeeplinkPush from '@shopgate/pwa-tracking/subscriptions/deeplinkPush';
 // Theme
 import navigator from 'Components/Navigator/subscriptions';
+import viewport from 'Components/Viewport/subscriptions';
 import category from 'Pages/Category/subscriptions';
 import coupon from 'Pages/Cart/components/CouponField/subscriptions';
 import favorites from 'Pages/Favorites/subscriptions';
@@ -32,7 +33,6 @@ import search from 'Pages/Search/subscriptions';
 import reviews from 'Pages/Reviews/subscriptions';
 import filterbar from 'Components/FilterBar/subscriptions';
 import writeReview from 'Pages/WriteReview/subscriptions';
-import cart from 'Pages/Cart/subscriptions';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 // Extensions
 import extensions from 'Extensions/subscribers';
@@ -66,6 +66,7 @@ const subscriptions = [
   trackingDeeplinkPush,
   // Theme subscribers.
   navigator,
+  viewport,
   category,
   coupon,
   favorites,
@@ -76,7 +77,6 @@ const subscriptions = [
   search,
   reviews,
   writeReview,
-  cart,
   // Extensions
   ...extensions,
 ];

--- a/styles/variables.js
+++ b/styles/variables.js
@@ -36,8 +36,5 @@ export default {
   tabBar: {
     height: 0,
   },
-  statusBar: {
-    height: 0,
-  },
   ...variables,
 };

--- a/styles/variables.js
+++ b/styles/variables.js
@@ -33,5 +33,11 @@ export default {
   paymentBar: {
     height: 78,
   },
+  tabBar: {
+    height: 0,
+  },
+  statusBar: {
+    height: 0,
+  },
   ...variables,
 };


### PR DESCRIPTION
- implemented the page insets from the iOS theme to deal with safe screen areas e.g. iPhone X notch
- added a --tabbar-height css variable which could be used by an extension to add a TabBar to the GMD theme
- small css adjustments to improve rendering of GMD components on iOS devices