### PR TITLE
PWA-765: Migrate product tracking

### DIFF
--- a/pages/subscribers.js
+++ b/pages/subscribers.js
@@ -14,7 +14,7 @@ import commerceSearch from '@shopgate/pwa-common-commerce/search/subscriptions';
 // PWA Tracking
 import trackingSetup from '@shopgate/pwa-tracking/subscriptions/setup';
 import trackingPages from '@shopgate/pwa-tracking/subscriptions/pages';
-// import trackingProduct from '@shopgate/pwa-tracking/subscriptions/product';
+import trackingProduct from '@shopgate/pwa-tracking/subscriptions/product';
 import trackingUser from '@shopgate/pwa-tracking/subscriptions/user';
 import trackingCart from '@shopgate/pwa-tracking/subscriptions/cart';
 // import trackingCheckout from '@shopgate/pwa-tracking/subscriptions/checkout';
@@ -58,7 +58,7 @@ const subscriptions = [
   // Tracking subscribers.
   trackingSetup,
   trackingPages,
-  // trackingProduct,
+  trackingProduct,
   trackingUser,
   trackingCart,
   // trackingCheckout,

--- a/pages/subscribers.js
+++ b/pages/subscribers.js
@@ -48,13 +48,6 @@ const subscriptions = [
   commonUser,
   commonMenu,
   commonRouter,
-  // Common Commerce subscribers.
-  commerceCart,
-  commerceFavorites,
-  commerceFilter,
-  commerceProduct,
-  commerceReviews,
-  commerceSearch,
   // Tracking subscribers.
   trackingSetup,
   trackingPages,
@@ -64,6 +57,13 @@ const subscriptions = [
   trackingCheckout,
   trackingSearch,
   trackingDeeplinkPush,
+  // Common Commerce subscribers.
+  commerceCart,
+  commerceFavorites,
+  commerceFilter,
+  commerceProduct,
+  commerceReviews,
+  commerceSearch,
   // Theme subscribers.
   app,
   navigator,


### PR DESCRIPTION
- Reactivated product tracking subscribers
- Prioritized the tracking in subscriber registration to solve an issue where `productIsReady$` from `pwa-tracking` didn't emit for the first opened product